### PR TITLE
M: Encoded "www.اسکریپت.com" to punycode

### DIFF
--- a/adblockfa.txt
+++ b/adblockfa.txt
@@ -907,7 +907,7 @@ zoomtech.ir###top_ads
 ||www.tarafdari.com/sites/default/files/apps/advertise/$image
 ||www.urlrate.net/banners/$image
 ||www.webhostingtalk.ir/ads/
-||www.اسکریپت.com/ads/$image
+||www.xn--mgbguh09aqiwi.com/ads/$image
 ||xperian.ir/xperian/wp-content/uploads/*.gif
 ||xscript.ir/*.gif
 ||yasdl.com/wp-content/uploads/*.gif


### PR DESCRIPTION
for details see https://adblockplus.org/development-builds/internationalized-domains-in-filters-are-now-expected-to-be-encoded-as-punycode